### PR TITLE
Fixed spotify support

### DIFF
--- a/modis/discord_modis/modules/music/api_music.py
+++ b/modis/discord_modis/modules/music/api_music.py
@@ -253,12 +253,16 @@ def get_ytvideos_from_list(queries):
     Returns:
         queue (list): The items obtained from the YouTube search
     """
-
     queue = []
-    for query in queries:
-        results = get_ytvideos(query)
+    if isinstance(queries, str) == True:
+        results = get_ytvideos(queries)
         if len(results) > 0:
             queue.append(results[0])
+    else:
+        for query in queries:
+            results = get_ytvideos(query)
+            if len(results) > 0:
+                queue.append(results[0])
 
     return queue
 


### PR DESCRIPTION
Missing String detection in the play from list. resulted in the string being converted to characters.
"rockstar - post malone" is converted to a youtube search of "r", "o", "c"... and so on

might also need to change the function name, not sure what really.