### PR TITLE
Removed limit of 100 songs from a spotify playlist

### DIFF
--- a/modis/discord_modis/modules/music/api_music.py
+++ b/modis/discord_modis/modules/music/api_music.py
@@ -406,8 +406,7 @@ def get_sp_tracks(results, query_type, query):
     if query_type == 'track':
         song_name = results['name'] # gather the name of the song by looking for the tag ['name']
         song_artist = results['artists'][0]['name'] # same as before, might only return the first artist, unsure
-        song = ("{} by {}".format(song_name,song_artist)) # joins both results
-        query = [song] # joins both results
+        query = ["{} by {}".format(song_name,song_artist)] # joins both results
         return (query)
     elif query_type == 'artist':
         for tracks in results['tracks'][:10]: # finds all tracks in the album

--- a/modis/discord_modis/modules/music/api_music.py
+++ b/modis/discord_modis/modules/music/api_music.py
@@ -406,8 +406,9 @@ def get_sp_tracks(results, query_type, query):
     if query_type == 'track':
         song_name = results['name'] # gather the name of the song by looking for the tag ['name']
         song_artist = results['artists'][0]['name'] # same as before, might only return the first artist, unsure
-        query.append = ("{} by {}".format(song_name,song_artist)) # joins both results
-
+        song = ("{} by {}".format(song_name,song_artist)) # joins both results
+        query = [song] # joins both results
+        return (query)
     elif query_type == 'artist':
         for tracks in results['tracks'][:10]: # finds all tracks in the album
              song_name = tracks['name']


### PR DESCRIPTION
with the current build, you will hang the thread the bot runs on by playing more than 150-250 songs. changes to how songs are loaded in from youtube will be needed

Changes: 

* removed string check in 'get_ytvideos_from_list' and made 'get_sp_tracks' only return lists

* added a check for over 100 songs in a playlist in the new 'sp_nextpage' function

* result finding in 'get_sp_track' moved to the new 'get_sp_results' to allow for the 'sp_nextpage' function to use the algorithm to get the song name and artist

* queries are now sent through 'get_sp_results' -> 'get_sp_tracks' -> 'sp_nextpage'